### PR TITLE
Updating nw builder and fixing build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ At this time Chrome is the only browser that this project and Rise Vision suppor
 ## Download
 The latest platform specific versions can be downloaded via one of the following links:
 
-- [Windows (32 bit)](http://s3.amazonaws.com/widget-preview-dl/0.1.7/widget-preview-win.zip) 
-- [Mac OSX](http://s3.amazonaws.com/widget-preview-dl/0.1.7/widget-preview-osx.zip) 
-- [Linux](http://s3.amazonaws.com/widget-preview-dl/0.1.7/widget-preview-linux32.zip)
+- [Windows (32 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-win32.zip) 
+- [Windows (64 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-win64.zip) 
+- [Mac OSX (32 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-osx32.zip) 
+- [Mac OSX (64 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-osx64.zip) 
+- [Linux (32 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-linux32.zip)
+- [Linux (64 bit)](http://s3.amazonaws.com/widget-preview-dl/0.2.0/widget-preview-linux64.zip)
 
 ### Installation
 Unzip the package and run the executable named **rv-widget-dev-app** (paths to the executable will differ upon platform). 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,14 +3,13 @@
 /*jshint node: true */
 
 var env = process.env.NODE_ENV || 'dev';
-var NwBuilder = require('node-webkit-builder');
+var NwBuilder = require('nw-builder');
 var gulp = require('gulp');
-var gutil = require('gulp-util');
 var bump = require('gulp-bump');
 var rename = require('gulp-rename');
-var clean = require('gulp-clean');
 var gutil = require('gulp-util');
 var fs = require('fs');
+var del = require("del");
 
 console.log('Environment is', env);
 
@@ -21,21 +20,10 @@ gulp.task('config', function() {
 });
 
 gulp.task('clean', function() {
-  return gulp.src('build/**/*', {read: false})
-    .pipe(clean({force: true}));
+  del(['./build/**']);
 });
 
-gulp.task('save-version', function () {
-  var json = require('./package.json');
-  if(!json.version) {
-    throw 'No version specified in package.json';
-  }
-  else {
-    fs.writeFileSync('build/VERSION', json.version);
-  }
-});
-
-gulp.task('build', ['config', 'clean', 'save-version'], function (callback) {
+gulp.task('build', ['config', 'clean'], function (callback) {
 
     var nw = new NwBuilder({
       files: ['web/**', 'server.js', 'package.json',
@@ -44,7 +32,8 @@ gulp.task('build', ['config', 'clean', 'save-version'], function (callback) {
         'node_modules/sockjs/**',
         'node_modules/open/**'
         ],
-      platforms: ['linux32', 'osx', 'win']
+      platforms: ['linux', 'osx', 'win'],
+      version: '0.12.2' // override version so it stops trying to download the latest - https://goo.gl/MX7Lu2
     });
 
     // Log stuff you want

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,10 +27,7 @@ gulp.task('build', ['config', 'clean'], function (callback) {
 
     var nw = new NwBuilder({
       files: ['web/**', 'server.js', 'package.json',
-        'node_modules/request/**',
-        'node_modules/express/**',
-        'node_modules/sockjs/**',
-        'node_modules/open/**'
+        'node_modules/**'
         ],
       platforms: ['linux', 'osx', 'win'],
       version: '0.12.2' // override version so it stops trying to download the latest - https://goo.gl/MX7Lu2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rv-widget-dev-app",
   "description": "Widget developer app.",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "web/index.html",
   "repository": {
     "type": "git",
@@ -19,14 +19,14 @@
     "height": 768
   },
   "dependencies": {
+    "del": "~1.1.1",
     "express": "~4.4.1",
     "gulp": "~3.8.0",
     "gulp-bump": "~0.1.8",
-    "gulp-clean": "^0.3.0",
     "gulp-rename": "^1.2.0",
     "gulp-run": "~1.5.2",
     "gulp-util": "^2.2.17",
-    "node-webkit-builder": "git://github.com/mllrsohn/node-webkit-builder.git",
+    "nw-builder": "git://github.com/nwjs/nw-builder.git",
     "open": "0.0.5",
     "request": "~2.36.0",
     "sockjs": "^0.3.9"


### PR DESCRIPTION
- Updating to current nw builder Git repo location
- Removing "save-version" gulp task as its causing an issue to the build process and the file is adding no value, version is stated in `package.json`
- nw builder now supports building 32 and 64 bit versions of all three OS
- applying version `0.12.2` to be used as a workaround to a current bug - https://goo.gl/MX7Lu2